### PR TITLE
Introducing Point monad

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val scalaV = scalaVersion := "2.12.5"
 
 val commons = Seq(
   scalaV,
-  version                   := "0.0.2",
+  version                   := "0.0.3",
   fork in Test              := true,
   parallelExecution in Test := false,
   organization              := "one.fluence",

--- a/core/src/main/scala/fluence/codec/MonadicalEitherArrow.scala
+++ b/core/src/main/scala/fluence/codec/MonadicalEitherArrow.scala
@@ -24,7 +24,7 @@ import cats.data.{EitherT, Kleisli}
 import cats.syntax.flatMap._
 import cats.syntax.compose._
 
-import scala.language.higherKinds
+import scala.language.{existentials, higherKinds}
 import scala.util.Try
 
 /**
@@ -64,7 +64,7 @@ abstract class MonadicalEitherArrow[E <: Throwable] {
      * @param input Input
      * @param F All internal maps and composes, as well as errors, are to be executed with this Monad
      */
-    def runF[F[_]](input: A)(implicit F: MonadError[F, Throwable]): F[B] =
+    def runF[F[_]](input: A)(implicit F: MonadError[F, EE] forSome {type EE >: E}): F[B] =
       runEither(input).flatMap(F.fromEither)
 
     /**
@@ -80,7 +80,7 @@ abstract class MonadicalEitherArrow[E <: Throwable] {
      *
      * @param F All internal maps and composes, as well as errors, are to be executed with this Monad
      */
-    def toKleisli[F[_]](implicit F: MonadError[F, Throwable]): Kleisli[F, A, B] =
+    def toKleisli[F[_]](implicit F: MonadError[F, EE] forSome {type EE >: E}): Kleisli[F, A, B] =
       Kleisli(input ⇒ runF[F](input))
 
     /**
@@ -93,6 +93,15 @@ abstract class MonadicalEitherArrow[E <: Throwable] {
       import cats.instances.try_._
       runF[Try](input).get
     }
+
+    /**
+      * Picks a point from the arrow, using the initial element (Unit) on the left.
+      *
+      * @param input Point to pick
+      * @return Picked point
+      */
+    def pointAt(input: A): Point[B] =
+      catsMonadicalEitherArrowChoice.lmap(this)(_ ⇒ input)
   }
 
   /**
@@ -183,6 +192,17 @@ abstract class MonadicalEitherArrow[E <: Throwable] {
   }
 
   /**
+    * Lift a function which returns a Func arrow with Unit on the left side.
+    *
+    * @param f Function to lift
+    */
+  def liftFuncPoint[A, B](f: A ⇒ Point[B]): Func[A,B] =
+    new Func[A,B]{
+      override def apply[F[_] : Monad](input: A): EitherT[F, E, B] =
+        f(input).apply[F](())
+    }
+
+  /**
    * Func that does nothing with input.
    */
   implicit def identityFunc[T]: Func[T, T] = liftFunc(identity)
@@ -216,6 +236,42 @@ abstract class MonadicalEitherArrow[E <: Throwable] {
   }
 
   /**
+    * Point type maps from Unit to a particular value of A, so it's just a lazy Func.
+    *
+    * @tparam A Output value type
+    */
+  type Point[A] = Func[Unit, A]
+
+  /**
+    * Point must obey MonadErrorLaws
+    */
+  implicit object catsMonadicalEitherPointMonad extends MonadError[Point, E] {
+    override def flatMap[A, B](fa: Point[A])(f: A ⇒ Point[B]): Point[B] =
+      new Func[Unit, B]{
+        override def apply[F[_] : Monad](input: Unit): EitherT[F, E, B] =
+          fa[F](()).flatMap(f(_).apply[F](()))
+      }
+
+    override def tailRecM[A, B](a: A)(f: A ⇒ Point[Either[A, B]]): Point[B] =
+      new Func[Unit, B]{
+        override def apply[F[_] : Monad](input: Unit): EitherT[F, E, B] =
+          Monad[EitherT[F, E, ?]].tailRecM(a)(f(_).apply[F](()))
+      }
+
+    override def raiseError[A](e: E): Point[A] =
+      liftFuncEither(_ ⇒ Left(e))
+
+    override def handleErrorWith[A](fa: Point[A])(f: E ⇒ Point[A]): Point[A] =
+      new Func[Unit, A]{
+        override def apply[F[_] : Monad](input: Unit): EitherT[F, E, A] =
+          fa[F](()).leftFlatMap(e ⇒ f(e).apply[F](()))
+      }
+
+    override def pure[A](x: A): Point[A] =
+      liftFunc(_ ⇒ x)
+  }
+
+  /**
    * Lifts pure direct and inverse functions into Bijection.
    *
    * @param direct Pure direct transformation.
@@ -236,6 +292,12 @@ abstract class MonadicalEitherArrow[E <: Throwable] {
    */
   def liftEitherB[A, B](direct: A ⇒ Either[E, B], inverse: B ⇒ Either[E, A]): Bijection[A, B] =
     Bijection(liftFuncEither(direct), liftFuncEither(inverse))
+
+  /**
+    * Lifts point functions into Bijection.
+    */
+  def liftPointB[A,B](direct: A ⇒ Point[B], inverse: B ⇒ Point[A]): Bijection[A,B] =
+    Bijection(liftFuncPoint(direct), liftFuncPoint(inverse))
 
   /**
    * Bijection that does no transformation.

--- a/core/src/test/scala/fluence/codec/PureCodecFuncTestInstances.scala
+++ b/core/src/test/scala/fluence/codec/PureCodecFuncTestInstances.scala
@@ -23,6 +23,13 @@ import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.ScalacheckShapeless._
 
 object PureCodecFuncTestInstances {
+  implicit def arbCodecError: Arbitrary[CodecError] =
+    Arbitrary(Gen.alphaLowerStr.map(CodecError(_)))
+
+  implicit def eqCodecError: Eq[CodecError] = Eq.fromUniversalEquals
+
+  implicit def cogenE: Cogen[CodecError] = Cogen.cogenString.contramap[CodecError](_.message)
+
   implicit def arbFunc[A: Arbitrary: Cogen, B: Arbitrary]: Arbitrary[PureCodec.Func[A, B]] =
     Arbitrary(
       Gen

--- a/core/src/test/scala/fluence/codec/PureCodecPointLawsSpec.scala
+++ b/core/src/test/scala/fluence/codec/PureCodecPointLawsSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017  Fluence Labs Limited
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package fluence.codec
+
+import cats.{Eq, Invariant}
+import cats.data.EitherT
+import cats.laws.discipline.{MonadErrorTests, SemigroupalTests}
+import cats.tests.CatsSuite
+import fluence.codec
+import org.scalacheck.ScalacheckShapeless._
+
+class PureCodecPointLawsSpec extends CatsSuite {
+
+  import PureCodecFuncTestInstances._
+
+  implicit def eqEitherTFEA: Eq[EitherT[PureCodec.Point, CodecError, Int]] =
+    Eq.instance{
+      case (aa,bb) ⇒
+        aa.value.unsafe(()) == bb.value.unsafe(())
+    }
+
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[PureCodec.Point](
+    new Invariant[PureCodec.Point]{
+      override def imap[A, B](fa: codec.PureCodec.Point[A])(f: A ⇒ B)(g: B ⇒ A): codec.PureCodec.Point[B] =
+        fa.map(f)
+    }
+  )
+
+  checkAll(
+    "PureCodec.Point.MonadErrorLaws",
+    MonadErrorTests[PureCodec.Point, CodecError].monadError[Int, String, Double]
+  )
+}


### PR DESCRIPTION
It's a common pattern to build a codec of a domain from codecs of its parts. However, doing it with `EitherT` is quite verbose.

Also we should keep an option to switch from `EitherT` to something like custom ADT, which could be more performant.

That's why `Point` is introduced. It allows use of any `Func`'s in monadic fashion to compose a complex `Func` from them.